### PR TITLE
Add optional serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ std = []
 
 [dependencies]
 getrandom = { version = "0.1", optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 getrandom = "0.1"
+serde_json = "1.0"

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -1,0 +1,70 @@
+use std::fmt;
+use serde::de::{Deserialize, Deserializer, Error, SeqAccess, Unexpected, Visitor};
+use serde::ser::{Serialize, Serializer};
+use crate::KeyPair;
+
+impl Serialize for KeyPair {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(&self[..])
+    }
+}
+
+impl<'de> Deserialize<'de> for KeyPair {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct KeyPairVisitor;
+
+        impl<'de> Visitor<'de> for KeyPairVisitor {
+            type Value = KeyPair;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a KeyPair")
+            }
+
+            fn visit_bytes<E: Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
+                KeyPair::from_slice(bytes).map_err(|_| {
+                    let unexpected = Unexpected::Bytes(bytes);
+                    E::invalid_value(unexpected, &self)
+                })
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut bytes = [0u8; KeyPair::BYTES];
+                let mut index = 0;
+
+                while let Some(b) = seq.next_element()? {
+                    if index == KeyPair::BYTES {
+                        return Err(A::Error::invalid_length(index + 1, &self));
+                    }
+
+                    bytes[index] = b;
+                    index += 1;
+                }
+
+                if index != KeyPair::BYTES {
+                    return Err(A::Error::invalid_length(index, &self));
+                }
+
+                KeyPair::from_slice(&bytes).map_err(|_| {
+                    A::Error::invalid_value(Unexpected::Seq, &self)
+                })
+            }
+        }
+
+        deserializer.deserialize_bytes(KeyPairVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{KeyPair, Seed};
+    use serde_json::Error;
+
+    #[test]
+    fn test_serialize() -> Result<(), Error> {
+        let expect = KeyPair::from_seed(Seed::generate());
+        let json = serde_json::to_string(&expect)?;
+        let actual: KeyPair = serde_json::from_str(&json)?;
+        assert_eq!(&expect[..], &actual[..]);
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 //! Cargo features:
 //!
 //! * `self-verify`: after having computed a new signature, verify that is it valid. This is slower, but improves resilience against fault attacks. It is enabled by default on WebAssembly targets.
+//! * `serde`: adds `Deserialize` and `Serialize` implementations for `KeyPair`.
 //! * `std`: disables `no_std` compatibility in order to make errors implement the standard `Error` trait.
 //! * `random` (enabled by default): adds `Default` and `generate` implementations to the `Seed` and `Noise` objects, in order to securely create random keys and noise.
 
@@ -65,3 +66,6 @@ mod sha512;
 
 pub use ed25519::*;
 pub use error::*;
+
+#[cfg(feature = "serde")]
+mod deser;


### PR DESCRIPTION
Hello, this PR adds an optional `serde` feature which adds `Serialize` and `Deserialize` implementations to `KeyPair`. In keeping with the compact spirit of the crate those are manual implementations that don't rely on the heavy code generation dependencies of `serde_derive`.

This might be too much additional complexity for a "compact" crate, but if it's something you'd like to support I'd be happy to push additional `Serialize` and `Deserialize` implementations for `PublicKey` as well.