### PR TITLE
Fixed a recursive invocation of Debug::fmt

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -99,7 +99,7 @@ pub struct Signature([u8; Signature::BYTES]);
 
 impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("{:x?}", self))
+        f.write_fmt(format_args!("{:x?}", &self.0))
     }
 }
 


### PR DESCRIPTION
The implementation of `Debug::fmt` in Signature was recursive, since
`format_args!("{:x?}", self)` calls `fmt`.

This can be tested by running

    let kp = ed25519_compact::KeyPair::from_seed([42u8; 32].into());
    let message = b"Hello, World!";
    let signature = kp.sk.sign(message, None);
    dbg!(&signature);