### PR TITLE
Add opt_size feature to reduce .text segment size at the cost of perf…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ traits = ["ed25519"]
 self-verify = []
 blind-keys = []
 std = []
+opt_size = []
 
 [dependencies]
 ct-codecs = { version = "1.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ println!("Signature as bytes: {:?}", signature_as_bytes);
 * `traits`: add support for the traits from the `ed25519` and `signature` crates.
 * `pem`: add support for importing/exporting keys as OpenSSL-compatible PEM files.
 * `blind-keys`: add support for key blinding.
+* `opt_size`: Enable size optimizations (based on benchmarks, 8-15% size reduction at the cost of 6.5-7% performance).

--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -8,7 +8,8 @@ pub type fiat_25519_u1 = u8;
 pub type fiat_25519_i1 = i8;
 pub type fiat_25519_i2 = i8;
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_addcarryx_u51(
     out1: &mut u64,
     out2: &mut fiat_25519_u1,
@@ -23,7 +24,8 @@ pub fn fiat_25519_addcarryx_u51(
     *out2 = x3;
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_subborrowx_u51(
     out1: &mut u64,
     out2: &mut fiat_25519_u1,
@@ -39,7 +41,8 @@ pub fn fiat_25519_subborrowx_u51(
     *out2 = ((0x0_i8.wrapping_sub((x2 as fiat_25519_i2))) as fiat_25519_u1);
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, arg3: u64) {
     let x1: fiat_25519_u1 = (!(!arg1));
     let x2: u64 = (((((0x0_i8.wrapping_sub((x1 as fiat_25519_i2))) as fiat_25519_i1) as i128)
@@ -48,7 +51,8 @@ pub fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, ar
     *out1 = x3;
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_carry_mul(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) {
     let x1: u128 = (((arg1[4]) as u128).wrapping_mul((((arg2[4]).wrapping_mul(0x13)) as u128)));
     let x2: u128 = (((arg1[4]) as u128).wrapping_mul((((arg2[3]).wrapping_mul(0x13)) as u128)));
@@ -114,7 +118,8 @@ pub fn fiat_25519_carry_mul(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5
     out1[4] = x44;
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_carry_square(out1: &mut [u64; 5], arg1: &[u64; 5]) {
     let x1: u64 = ((arg1[4]).wrapping_mul(0x13));
     let x2: u64 = (x1.wrapping_mul(0x2));
@@ -173,7 +178,8 @@ pub fn fiat_25519_carry_square(out1: &mut [u64; 5], arg1: &[u64; 5]) {
     out1[4] = x42;
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_carry(out1: &mut [u64; 5], arg1: &[u64; 5]) {
     let x1: u64 = (arg1[0]);
     let x2: u64 = ((x1 >> 51).wrapping_add((arg1[1])));
@@ -194,7 +200,8 @@ pub fn fiat_25519_carry(out1: &mut [u64; 5], arg1: &[u64; 5]) {
     out1[4] = x12;
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_add(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) {
     let x1: u64 = ((arg1[0]).wrapping_add((arg2[0])));
     let x2: u64 = ((arg1[1]).wrapping_add((arg2[1])));
@@ -208,7 +215,8 @@ pub fn fiat_25519_add(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) {
     out1[4] = x5;
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_sub(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) {
     let x1: u64 = ((0xfffffffffffdau64.wrapping_add((arg1[0]))).wrapping_sub((arg2[0])));
     let x2: u64 = ((0xffffffffffffeu64.wrapping_add((arg1[1]))).wrapping_sub((arg2[1])));
@@ -222,7 +230,8 @@ pub fn fiat_25519_sub(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) {
     out1[4] = x5;
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_opp(out1: &mut [u64; 5], arg1: &[u64; 5]) {
     let x1: u64 = (0xfffffffffffdau64.wrapping_sub((arg1[0])));
     let x2: u64 = (0xffffffffffffeu64.wrapping_sub((arg1[1])));
@@ -236,7 +245,8 @@ pub fn fiat_25519_opp(out1: &mut [u64; 5], arg1: &[u64; 5]) {
     out1[4] = x5;
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 pub fn fiat_25519_selectznz(
     out1: &mut [u64; 5],
     arg1: fiat_25519_u1,
@@ -433,7 +443,8 @@ static FE_D2: Fe = Fe([
     633789495995903,
 ]);
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 fn load_8u(s: &[u8]) -> u64 {
     (s[0] as u64)
         | ((s[1] as u64) << 8)
@@ -445,22 +456,26 @@ fn load_8u(s: &[u8]) -> u64 {
         | ((s[7] as u64) << 56)
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 fn load_4u(s: &[u8]) -> u64 {
     (s[0] as u64) | ((s[1] as u64) << 8) | ((s[2] as u64) << 16) | ((s[3] as u64) << 24)
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 fn load_4i(s: &[u8]) -> i64 {
     load_4u(s) as i64
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 fn load_3u(s: &[u8]) -> u64 {
     (s[0] as u64) | ((s[1] as u64) << 8) | ((s[2] as u64) << 16)
 }
 
-#[inline]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline)]
 fn load_3i(s: &[u8]) -> i64 {
     load_3u(s) as i64
 }

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -10,7 +10,8 @@
     clippy::unreadable_literal
 )]
 
-#[inline(always)]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline(always))]
 fn load_be(base: &[u8], offset: usize) -> u64 {
     let addr = &base[offset..];
     (addr[7] as u64)
@@ -23,7 +24,8 @@ fn load_be(base: &[u8], offset: usize) -> u64 {
         | (addr[0] as u64) << 56
 }
 
-#[inline(always)]
+#[cfg_attr(feature = "opt_size", inline(never))]
+#[cfg_attr(not(feature = "opt_size"), inline(always))]
 fn store_be(base: &mut [u8], offset: usize, x: u64) {
     let addr = &mut base[offset..];
     addr[7] = x as u8;
@@ -50,37 +52,44 @@ impl W {
         W(w)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn Ch(x: u64, y: u64, z: u64) -> u64 {
         (x & y) ^ (!x & z)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn Maj(x: u64, y: u64, z: u64) -> u64 {
         (x & y) ^ (x & z) ^ (y & z)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn Sigma0(x: u64) -> u64 {
         x.rotate_right(28) ^ x.rotate_right(34) ^ x.rotate_right(39)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn Sigma1(x: u64) -> u64 {
         x.rotate_right(14) ^ x.rotate_right(18) ^ x.rotate_right(41)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn sigma0(x: u64) -> u64 {
         x.rotate_right(1) ^ x.rotate_right(8) ^ (x >> 7)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn sigma1(x: u64) -> u64 {
         x.rotate_right(19) ^ x.rotate_right(61) ^ (x >> 6)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn M(&mut self, a: usize, b: usize, c: usize, d: usize) {
         let w = &mut self.0;
         w[a] = w[a]
@@ -89,7 +98,8 @@ impl W {
             .wrapping_add(Self::sigma0(w[d]));
     }
 
-    #[inline]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn expand(&mut self) {
         self.M(0, (0 + 14) & 15, (0 + 9) & 15, (0 + 1) & 15);
         self.M(1, (1 + 14) & 15, (1 + 9) & 15, (1 + 1) & 15);
@@ -109,7 +119,8 @@ impl W {
         self.M(15, (15 + 14) & 15, (15 + 9) & 15, (15 + 1) & 15);
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn F(&mut self, state: &mut State, i: usize, k: u64) {
         let t = &mut state.0;
         t[(16 - i + 7) & 7] = t[(16 - i + 7) & 7]
@@ -250,7 +261,8 @@ impl State {
         State(t)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "opt_size", inline(never))]
+    #[cfg_attr(not(feature = "opt_size"), inline(always))]
     fn add(&mut self, x: &State) {
         let sx = &mut self.0;
         let ex = &x.0;


### PR DESCRIPTION
…ormance.

Analogous to https://github.com/jedisct1/rust-hmac-sha256/pull/2, except several months late :D!

# Benchmarks

Benchmarks were done targeting an [Adafruit Feather RP2040](https://www.adafruit.com/product/4884), running at the default 125 MHz. My `rustc` info is as follows:

```
rustc 1.60.0-nightly (51126be1b 2022-01-24)
binary: rustc
commit-hash: 51126be1b260216b41143469086e6e6ee567647e
commit-date: 2022-01-24
host: x86_64-pc-windows-gnu
release: 1.60.0-nightly
LLVM version: 13.0.0
```

I used the following `cargo` profiles (`dev` == Debug) and varied the `opt-level`:

```toml
[profile.dev]
codegen-units = 1
debug = 2
debug-assertions = true
incremental = false
overflow-checks = true

[profile.release]
codegen-units = 1
debug = 2
debug-assertions = false
incremental = false
lto = 'fat'
overflow-checks = false
```

## Results

|Profile|opt-level|opt_size?|`.text` size|  uSecs| `cargo bloat`|`.text` diff| uSecs diff| `bloat` diff|
|-------|---------|---------|------------|-------|--------------|------------|-----------|-------------|
|  Debug|        0|       No|      422040|      X|68.0% 254.2KiB|            |           |             |
|  Debug|        0|      Yes|      345656|      X|60.0% 179.7KiB|      -18.1%|          X|       -29.3%|
|  Debug|        1|       No|      150456| 828569| 68.4% 83.2KiB|            |           |             |
|  Debug|        1|      Yes|      139728| 857174| 65.2% 71.9KiB|      -7.13%|     +3.45%|       -13.6%|
|  Debug|        2|       No|      136508| 717383| 70.6% 79.1KiB|            |           |             |
|  Debug|        2|      Yes|      126848| 771214| 67.6% 69.0KiB|      -7.08%|     +7.50%|      -12.77%|
|  Debug|        3|       No|      196944| 801755|80.8% 138.5KiB|            |           |             |
|  Debug|        3|      Yes|      128576| 852571| 68.4% 71.2KiB|     -34.71%|     +6.33%|      -48.59%|
|  Debug|      "s"|       No|      121396| 685952| 64.7% 62.2KiB|            |           |             |
|  Debug|      "s"|      Yes|      112180| 732091| 60.9% 52.8KiB|      -7.59%|     +6.73%|      -12.64%|
|  Debug|      "z"|       No|      124028| 716984| 63.2% 61.2KiB|            |           |             |
|  Debug|      "z"|      Yes|      112532| 859824| 58.3% 49.8KiB|      -9.27%|    +19.92%|      -18.62%|
|Release|        1|       No|      111640| 694665| 61.8% 59.3KiB|            |           |             |
|Release|        1|      Yes|       99444| 744662| 56.2% 47.1KiB|     -12.26%|     +7.20%|      -20.57%|
|Release|        2|       No|       91116| 785331| 71.4% 59.1KiB|            |           |             |
|Release|        2|      Yes|       79992| 775112| 67.0% 48.1KiB|     -12.21%|     -1.30%|      -18.61%|
|Release|        3|       No|      149816| 825196|84.5% 118.6KiB|            |           |             |
|Release|        3|      Yes|       79848| 864777| 69.8% 50.2KiB|     -46.70%|     +4.80%|      -57.67%|
|Release|      "s"|       No|       73420| 659434| 67.3% 44.0KiB|            |           |             |
|Release|      "s"|      Yes|       62788| 703593| 61.1% 33.5KiB|     -14.48%|     +6.70%|      -23.86%|
|Release|      "z"|       No|       84700| 766108| 40.6% 28.6KiB|            |           |             |
|Release|      "z"|      Yes|       72916| 797148| 31.6% 18.6KiB|     -13.91%|     +4.05%|      -34.97%|

* An "X" means "USB enumeration timed out, so I couldn't get a measurement".
* The `cargo bloat` field represents the cumulative `.text` and `Size` reported by running: `cargo bloat --release --example ed22519-bench --filter ed25519_compact [--features=opt_size]`".
* `.text` size is in bytes.

Out of curiosity, I also wanted to see what would happen if I used a different `opt-level` for `ed25519_compact` compared to the other deps.

### `opt-level=3`, `ed25519_compact` `opt-level="s"`

|opt_size?|`.text` size|  uSecs| `cargo bloat`|`.text` diff| uSecs diff| `bloat` diff|
|----------|-----------|-------|---------------|----------|------------|------------|
|       No|       73764| 659047| 66.9% 44.1KiB|            |           |             |
|      Yes|       63132| 725665| 60.7% 33.7KiB|     -14.41%|    +10.11%|      -23.58%|

### `opt-level="s"`, `ed25519_compact` `opt-level="z"`

|opt_size?|`.text` size|  uSecs| `cargo bloat`|`.text` diff| uSecs diff| `bloat` diff|
|----------|-----------|-------|---------------|----------|------------|------------|
|       No|       72272| 672932| 66.1% 42.2KiB|            |           |             |
|      Yes|       60504| 803764| 58.6% 30.6KiB|     -16.28%|    +19.44%|      -27.49%|

My takeaway from these results is that the `opt-size` feature can be a net-win for time _and_ space, but you need to do benchmarks to be sure. `opt-level=3` does _not_ appear to be a good idea for constrained environments period.

## Benchmark Code

I provide this for completeness only, I suggest using a [project template](https://github.com/rp-rs/rp2040-project-template) and paste the below code into it.

### Source

```rust
#![no_std]
#![no_main]

use core::fmt::{self, Write};

use adafruit_feather_rp2040 as bsp;
use bsp::hal::{self,
    clocks::init_clocks_and_plls,
    pac,
    watchdog::Watchdog,
};
use cortex_m_rt::entry;
use defmt::*;
use defmt_rtt as _;
use ed25519_compact::{KeyPair, Seed, Noise};
use getrandom::register_custom_getrandom;
use panic_probe as _;
use usb_device::{class_prelude::*, prelude::*};
use usbd_serial::SerialPort;

static mut STATE: u8 = 0;
// Safety: No interrupts are used in this demo- single-threaded.
pub fn dummy_rng(buf: &mut [u8]) -> Result<(), getrandom::Error> {
    let mut iter_u8 = unsafe { STATE };

    for b in buf {
        *b = iter_u8;
        iter_u8 += 1;
    }

    // Doesn't work... why?
    // (unsafe { STATE }) = iter_u8;
    unsafe { STATE = iter_u8 };
    Ok(())
}

register_custom_getrandom!(dummy_rng);

// Slices don't implement fmt::Write, so use a newtype just for this application.
struct NumFormatter32([u8; 10]);

impl fmt::Write for NumFormatter32 {
    fn write_str(&mut self, s: &str) -> fmt::Result {
        if s.len() > 10 {
            Err(fmt::Error)
        } else {
            let bytes = s.as_bytes();
            let correct_size_slice = &mut self.0[..s.len()];

            correct_size_slice.copy_from_slice(bytes);
            Ok(())
        }
    }
}

#[entry]
fn main() -> ! {
    // info!("Program start");
    let mut pac = pac::Peripherals::take().unwrap();
    let mut watchdog = Watchdog::new(pac.WATCHDOG);

    // External high-speed crystal on the pico board is 12Mhz
    let external_xtal_freq_hz = 12_000_000u32;
    let clocks = init_clocks_and_plls(
        external_xtal_freq_hz,
        pac.XOSC,
        pac.CLOCKS,
        pac.PLL_SYS,
        pac.PLL_USB,
        &mut pac.RESETS,
        &mut watchdog,
    )
    .ok()
    .unwrap();

    // Set up the USB driver
    let usb_bus = UsbBusAllocator::new(hal::usb::UsbBus::new(
        pac.USBCTRL_REGS,
        pac.USBCTRL_DPRAM,
        clocks.usb_clock,
        true,
        &mut pac.RESETS,
    ));

    // Set up the USB Communications Class Device driver
    let mut serial = SerialPort::new(&usb_bus);

    // Create a USB device with a fake VID and PID
    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
        .manufacturer("Fake company")
        .product("Serial port")
        .serial_number("TEST")
        .device_class(2) // from: https://www.usb.org/defined-class-codes
        .build();

    let timer = hal::Timer::new(pac.TIMER, &mut pac.RESETS);
    let start = timer.get_counter();

    // A message to sign and verify.
    let message = b"test";

    // Generates a new key pair using a random seed.
    // A given seed will always produce the same key pair.
    let key_pair = KeyPair::from_seed(Seed::default());

    // Computes a signature for this message using the secret part of the key pair.
    let signature = key_pair.sk.sign(message, Some(Noise::default()));

    // Verifies the signature using the public part of the key pair.
    crate::assert!(key_pair.pk.verify(message, &signature).is_ok());

    let end = timer.get_counter();

    let mut formatted_num = NumFormatter32([0; 10]);
    let _ = core::write!(&mut formatted_num, "{}", end - start);

    // We are done! Init USB and write results. Yes, this is a hack!
    let mut wrote_msg = false;
    loop {
        usb_dev.poll(&mut [&mut serial]);

        if !wrote_msg && timer.get_counter() >= 2_000_000 {
            wrote_msg = true;
            serial.write(b"ed22519 test took ").unwrap();
            serial.write(&formatted_num.0).unwrap();
            serial.write(b" cycles \r\n").unwrap();
        }
    }
}
```

### `Cargo.toml` Deps

```toml
[dependencies]
cortex-m = "0.7.3"
cortex-m-rt = "0.7.0"
embedded-hal = { version = "0.2.5", features=["unproven"] }
embedded-time = "0.12.0"

defmt = "0.3.0"
defmt-rtt = "0.3.0"
panic-probe = { version = "0.3.0", features = ["print-defmt"] }
adafruit-feather-rp2040  = "0.1.0"
usb-device= "0.2.8"
usbd-serial = "0.1.1"
usbd-hid = "0.5.1"
getrandom = { version = "0.2.4", features=["custom"] }
ed25519-compact = { version = "1.0.11", default_features = false, features=["random"], path = "C:\\msys64\\home\\William\\Projects\\MSP430\\rust-ed25519-compact"}

[features]
opt_size = ["ed25519-compact/opt_size"]
```