### PR TITLE
feat: add zeroizing feature to implement zeroize::Zeroize for key types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,13 @@ std = []
 opt_size = []
 disable-signatures = []
 x25519 = []
+zeroizing = ["zeroize"]
 
 [dependencies]
 ct-codecs = { version = "1.1", optional = true }
 getrandom = { version = "0.2", optional = true }
 ed25519 = { version = "1.5", optional = true }
+zeroize = { version = "1.5", optional = true, default-features = false }
 
 [dev-dependencies]
 getrandom = "0.2"

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ println!("Signature as bytes: {:?}", signature_as_bytes);
 * `opt_size`: Enable size optimizations (based on benchmarks, 8-15% size reduction at the cost of 6.5-7% performance).
 * `x25519`: Enable support for the X25519 key exchange system.
 * `disable-signatures`: Disable support for signatures, and only compile support for X25519.
+* `zeroizing`: Implements the [`Zeroize`](https://docs.rs/zeroize) trait for all public and secret keys as well as noise and seeds. This is not a "zeroize on `Drop`" implementation, call `.zeroize()` manually.

--- a/src/common.rs
+++ b/src/common.rs
@@ -65,3 +65,10 @@ impl DerefMut for Seed {
         &mut self.0
     }
 }
+
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for Seed {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -44,6 +44,13 @@ impl Deref for PublicKey {
     }
 }
 
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for PublicKey {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 /// A secret key.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SecretKey([u8; SecretKey::BYTES]);
@@ -96,6 +103,13 @@ impl DerefMut for SecretKey {
     }
 }
 
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for SecretKey {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 /// A key pair.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct KeyPair {
@@ -103,6 +117,14 @@ pub struct KeyPair {
     pub pk: PublicKey,
     /// Secret key part of the key pair.
     pub sk: SecretKey,
+}
+
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for KeyPair {
+    fn zeroize(&mut self) {
+        self.pk.zeroize();
+        self.sk.zeroize();
+    }
 }
 
 /// An Ed25519 signature.
@@ -147,6 +169,13 @@ impl Deref for Signature {
     /// Returns a signture as bytes.
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for Signature {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 
@@ -358,6 +387,13 @@ impl Noise {
     /// Generates random noise.
     pub fn generate() -> Self {
         Noise::default()
+    }
+}
+
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for Noise {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
     }
 }
 

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -104,6 +104,13 @@ impl Deref for PublicKey {
     }
 }
 
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for PublicKey {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 /// A secret key.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SecretKey([u8; SecretKey::BYTES]);
@@ -159,6 +166,13 @@ impl DerefMut for SecretKey {
     }
 }
 
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for SecretKey {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 /// A key pair.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct KeyPair {
@@ -194,6 +208,14 @@ impl Deref for KeyPair {
     /// Returns a key pair as bytes.
     fn deref(&self) -> &Self::Target {
         &self.sk
+    }
+}
+
+#[cfg(feature = "zeroizing")]
+impl zeroize::Zeroize for KeyPair {
+    fn zeroize(&mut self) {
+        self.pk.zeroize();
+        self.sk.zeroize();
     }
 }
 


### PR DESCRIPTION
It's not possible to implement `ZeroizeOnDrop` (and zeroizing on `Drop`) yet because that would be a
breaking change in API if the feature was enabled, meaning the crate version would have to move to
2.0.0.

Implementing Zeroize as I have done will make it possible to write zeroizing wrappers by users or
simply call `.zeroize()` in specific points without trouble.