### PR TITLE
Expose scalar multiplication on ed25519

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-compact"
-version = "2.0.3"
+version = "2.0.5"
 authors = ["Frank Denis <github@pureftpd.org>"]
 edition = "2018"
 description = "A small, self-contained, wasm-friendly Ed25519 implementation"

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use core::ptr;
 use core::sync::atomic;
 
 use super::error::Error;
-use super::{sha512, KeyPair};
+use super::sha512;
 
 /// A seed, which a key pair can be derived from.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -35,9 +35,10 @@ impl Seed {
     }
 
     /// Get the scalar value of the seed.
+    #[cfg(not(feature = "disable-signatures"))]
     pub fn scalar(&self) -> [u8; 32] {
         let hash_output = sha512::Hash::hash(&self[..]);
-        let (scalar, _) = KeyPair::split(&hash_output, false, true);
+        let (scalar, _) = crate::KeyPair::split(&hash_output, false, true);
 
         scalar
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,6 +3,7 @@ use core::ptr;
 use core::sync::atomic;
 
 use super::error::Error;
+use super::{sha512, KeyPair};
 
 /// A seed, which a key pair can be derived from.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -31,6 +32,14 @@ impl Seed {
         }
         seed_.copy_from_slice(seed);
         Ok(Seed::new(seed_))
+    }
+
+    /// Get the scalar value of the seed.
+    pub fn scalar(&self) -> [u8; 32] {
+        let hash_output = sha512::Hash::hash(&self[..]);
+        let (scalar, _) = KeyPair::split(&hash_output, false, true);
+
+        scalar
     }
 
     /// Tentatively overwrite the content of the seed with zeros.

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -397,10 +397,7 @@ impl KeyPair {
         if seed.iter().fold(0, |acc, x| acc | x) == 0 {
             panic!("All-zero seed");
         }
-        let (scalar, _) = {
-            let hash_output = sha512::Hash::hash(&seed[..]);
-            KeyPair::split(&hash_output, false, true)
-        };
+        let scalar = seed.scalar();
         let pk = ge_scalarmult_base(&scalar).to_bytes();
         let mut sk = [0u8; 64];
         sk[0..32].copy_from_slice(&*seed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::error::*;
 #[cfg(not(feature = "disable-signatures"))]
 mod ed25519;
 #[cfg(not(feature = "disable-signatures"))]
-mod edwards25519;
+pub mod edwards25519;
 
 #[cfg(not(feature = "disable-signatures"))]
 pub use crate::ed25519::*;


### PR DESCRIPTION
I've made some of the underlying operations public, to allow things like DH to be implemented using this crate.

Note that I've also bumped the version to v2.0.5, because it seems like crates.io has a v2.0.4 which doesn't appear on GitHub.. This was causing issues with dependency resolution for me, when using this branch.

Closes #28 