### PR TITLE
Update `getrandom` to `0.3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,20 @@ disable-signatures = []
 x25519 = []
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", optional = true, features = ["js"] }
+getrandom = { version = "0.3", optional = true, features = ["wasm_js"] }
 
 [target.'cfg(not(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown")))'.dependencies]
-getrandom = { version = "0.2", optional = true }
+getrandom = { version = "0.3", optional = true }
 
 [dependencies]
 ct-codecs = { version = "1.1", optional = true }
 ed25519 = { version = "2.2", optional = true }
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dev-dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [target.'cfg(not(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown")))'.dev-dependencies]
-getrandom = { version = "0.2" }
+getrandom = { version = "0.3" }
 
 [dev-dependencies]
 ct-codecs = "1.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -44,7 +44,7 @@ impl Default for Seed {
     /// Generates a random seed.
     fn default() -> Self {
         let mut seed = [0u8; Seed::BYTES];
-        getrandom::getrandom(&mut seed).expect("RNG failure");
+        getrandom::fill(&mut seed).expect("RNG failure");
         Seed(seed)
     }
 }

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -517,7 +517,7 @@ impl Default for Noise {
     /// Generates random noise.
     fn default() -> Self {
         let mut noise = [0u8; Noise::BYTES];
-        getrandom::getrandom(&mut noise).expect("RNG failure");
+        getrandom::fill(&mut noise).expect("RNG failure");
         Noise(noise)
     }
 }

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -247,7 +247,7 @@ impl KeyPair {
     #[cfg(feature = "random")]
     pub fn generate() -> KeyPair {
         let mut sk = [0u8; SecretKey::BYTES];
-        getrandom::getrandom(&mut sk).expect("getrandom");
+        getrandom::fill(&mut sk).expect("getrandom");
         if Fe::from_bytes(&sk).is_zero() {
             panic!("All-zero secret key");
         }


### PR DESCRIPTION
This bumps `getrandom` to the `0.3` release. Used by the new `rand_core` traits and co. from `0.9` and further.