### PR TITLE
Sha512 pub export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-compact"
-version = "2.3.0"
+version = "2.4.0"
 authors = ["Frank Denis <github@pureftpd.org>"]
 edition = "2018"
 description = "A small, self-contained, wasm-friendly Ed25519 implementation"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 mod common;
 mod error;
 mod field25519;
-mod sha512;
+pub mod sha512;
 
 pub use crate::common::*;
 pub use crate::error::*;


### PR DESCRIPTION
Right now I need to have Sha512 crate in my project as well, duplicating functionality. Using this pub export prevents me from having to duplicate sha512.

We can gate this behind a feature if that is preferred. Just let me know  :)